### PR TITLE
Make the window the same size as Discord's

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,8 +55,8 @@
     "windows": [
       {
         "title": "Discord",
-        "width": 800,
-        "height": 600,
+        "width": 940,
+        "height": 500,
         "resizable": true,
         "fullscreen": false,
         "visible": false,


### PR DESCRIPTION
This makes the size of the window the same of the original Discord client