### PR TITLE
Various commits

### DIFF
--- a/dist/splashscreen.html
+++ b/dist/splashscreen.html
@@ -31,14 +31,6 @@
       bottom: 45px;
     }
   </style>
-  <script>
-    // Wait 1s, then close the splashscreen window.
-    setTimeout(
-      function() {
-        window.__TAURI__.invoke("close_splashscreen");
-      }
-    , 1000);
-  </script>
   <body oncontextmenu="return false;">
       <div>
       <video width="320" height="240" autoplay muted loop>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,10 @@ custom-protocol = [ "tauri/custom-protocol" ]
 
 [patch.crates-io]
 wry = { git = "https://github.com/tauri-apps/wry", branch = "fix/cursor-flicker" }
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+incremental = false
+opt-level = "s"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 build = "src/build.rs"
 
 [build-dependencies]
-tauri-build = { version = "1.0.0-beta.2" }
+tauri-build = { version = "1.0.0-beta.3" }
 
 [dependencies]
 serde_json = "1.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,3 +20,6 @@ tauri = { version = "1.0.0-beta.5", features = ["api-all", "menu", "system-tray"
 [features]
 default = [ "custom-protocol" ]
 custom-protocol = [ "tauri/custom-protocol" ]
+
+[patch.crates-io]
+wry = { git = "https://github.com/tauri-apps/wry", branch = "fix/cursor-flicker" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,18 +11,8 @@ use tauri::{Manager, SystemTray, CustomMenuItem, SystemTrayMenu, SystemTrayEvent
 // Plugin imports
 use plugins::{
   add_window_bar::WindowBarPlugin,
+  splashscreen::SplashscreenPlugin,
 };
-
-/// This command:
-/// - Shows the splashscreen window, because the user could see a blank window for a second otherwise
-/// - Is accessible with `show_splashscreen`
-#[tauri::command]
-fn show_splashscreen(window: tauri::Window) {
-  // Show the splashscreen
-  if let Some(splashscreen) = window.get_window("splashscreen") {
-    splashscreen.show().unwrap();
-  }
-}
 
 /// This command:
 /// - Closes the splashscreen window
@@ -30,16 +20,17 @@ fn show_splashscreen(window: tauri::Window) {
 /// - Is accessible with `close_splashscreen`
 #[tauri::command]
 fn close_splashscreen(window: tauri::Window) {
-  // Close the splashscreen
-  window.get_window("splashscreen").unwrap().close().unwrap();
-  // Show the main window
-  window.get_window("main").unwrap().show().unwrap();
-  // Maximize it
-  window.get_window("main").unwrap().maximize().unwrap();
+    // Close the splashscreen window
+    window.get_window("splashscreen").unwrap().close().unwrap();
+    // Show the main window
+    window.get_window("main").unwrap().show().unwrap();
+    // Maximize it
+    window.get_window("main").unwrap().maximize().unwrap();
 }
 
 fn main() {
   // Instance plugins
+  let splashscreen_plugin = SplashscreenPlugin::new();
   let window_bar_plugin = WindowBarPlugin::new();
 
   // We can't make a separate file for a Desktop Tray yet, so we make it here
@@ -53,8 +44,9 @@ fn main() {
   // Start Tauri
   tauri::Builder::default()
     // Register the commands
-    .invoke_handler(tauri::generate_handler![show_splashscreen, close_splashscreen])
+    .invoke_handler(tauri::generate_handler![close_splashscreen])
     // Register the plugins
+    .plugin(splashscreen_plugin)
     .plugin(window_bar_plugin)
     // Register the desktop tray
     .system_tray(desktop_tray)

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,1 +1,2 @@
 pub mod add_window_bar;
+pub mod splashscreen;

--- a/src-tauri/src/plugins/splashscreen.rs
+++ b/src-tauri/src/plugins/splashscreen.rs
@@ -1,0 +1,60 @@
+/// PLUGIN: SPLASHSCREEN
+/// NAME: splashscreen
+/// IMPORT AS: SplashscreenPlugin
+/// 
+/// AUTHOR: DrPuc
+/// DOES: Waits for Discord's HTML to hide the splashscreen and show the main window.
+
+use tauri::{plugin::Plugin, Runtime, Window, Invoke};
+
+use std::thread::sleep;
+use std::time::Duration;
+
+pub struct SplashscreenPlugin<R: Runtime> {
+  invoke_handler: Box<dyn Fn(Invoke<R>) + Send + Sync>,
+}
+
+impl<R: Runtime> SplashscreenPlugin<R> {
+  pub fn new() -> Self {
+    Self {
+      invoke_handler: Box::new(tauri::generate_handler![]),
+    }
+  }
+}
+
+impl<R: Runtime> Plugin<R> for SplashscreenPlugin<R> {
+  // The plugin name
+  fn name(&self) -> &'static str {
+    "splashscreen"
+  }
+
+  // The JS script to evaluate on initialization
+  fn initialization_script(&self) -> Option<String> {
+    Some(String::from("console.log('[discord-tauri] Splashscreen loaded.');"))
+  }
+
+  // Callback invoked when a Window is created
+  fn created(&mut self, window: Window<R>) {
+    // Create a new thread so we don't panic while using the window
+    std::thread::spawn(move || {
+      // If the window isn't the main one, return
+      if window.label().to_string() != "main" {
+        return
+      }
+
+      // Wait 500ms
+      sleep(Duration::from_millis(500));
+
+      // Execute JS code in the main window
+      window.eval(r#"
+        // Once the HTML is ready, we call `close_splashscreen`
+        window.__TAURI__.invoke('close_splashscreen');
+      "#).unwrap();
+    });
+  }
+
+  // Extend the invoke handler
+  fn extend_api(&mut self, message: Invoke<R>) {
+    (self.invoke_handler)(message)
+  }
+}


### PR DESCRIPTION
This PR:
- Updates tauri-build
- Makes the splashscreen a Tauri plugin
- Patches the mouse flicker until Wry releases the patch
- Makes the release 56% smaller (6210KB -> 2700KB)