### PR TITLE
Clarify the splashscreen code

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,20 +11,6 @@ use tauri::{CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu
 // Plugin imports
 use plugins::{add_window_bar::WindowBarPlugin, splashscreen::SplashscreenPlugin};
 
-/// This command:
-/// - Closes the splashscreen window
-/// - Un-hides the main window
-/// - Is accessible with `close_splashscreen`
-#[tauri::command]
-fn close_splashscreen(window: tauri::Window) {
-  // Close the splashscreen window
-  window.get_window("splashscreen").unwrap().close().unwrap();
-  // Show the main window
-  window.get_window("main").unwrap().show().unwrap();
-  // Maximize it
-  window.get_window("main").unwrap().maximize().unwrap();
-}
-
 fn main() {
   // Instance plugins
   let splashscreen_plugin = SplashscreenPlugin::new();
@@ -41,7 +27,7 @@ fn main() {
   // Start Tauri
   tauri::Builder::default()
     // Register the commands
-    .invoke_handler(tauri::generate_handler![close_splashscreen])
+    .invoke_handler(tauri::generate_handler![])
     // Register the plugins
     .plugin(splashscreen_plugin)
     .plugin(window_bar_plugin)

--- a/src-tauri/src/plugins/splashscreen.rs
+++ b/src-tauri/src/plugins/splashscreen.rs
@@ -36,25 +36,21 @@ impl<R: Runtime> Plugin<R> for SplashscreenPlugin<R> {
 
   // Callback invoked when a Window is created
   fn created(&mut self, window: Window<R>) {
-    // Create a new thread so we don't panic while using the window
+    // Create a new thread so we can wait on it
     std::thread::spawn(move || {
-      // If the window isn't the main one, return
-      if window.label().to_string() != "main" {
-        return;
-      }
-
       // Wait 500ms
       sleep(Duration::from_millis(500));
 
-      // Execute JS code in the main window
-      window
-        .eval(
-          r#"
-        // Once the HTML is ready, we call `close_splashscreen`
-        window.__TAURI__.invoke('close_splashscreen');
-      "#,
-        )
-        .unwrap();
+      // Close the splashscreen window
+      if window.label().to_string() == "splashscreen" {
+        window.close().unwrap();
+      }
+
+      // Show and maximize the main window
+      if window.label().to_string() == "main" {
+        window.show().unwrap();
+        window.maximize().unwrap();
+      }
     });
   }
 


### PR DESCRIPTION
This PR:
- Removes `close_splashscreen` from main.rs
- Removes the usage of `eval` on splashscreen.rs