### PR TITLE
Release version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Discord Tauri</h1>
 
 <p align="center">
-    Discord Tauri is a work in progress Discord wrapper made in [Tauri](https://tauri.studio).
+    Discord Tauri is a work in progress Discord wrapper made in <a href="https://tauri.studio">Tauri</a>.
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,37 @@
-<h1 align="center">Discord-Tauri</h1>
+<h1 align="center">Discord Tauri</h1>
 
 <p align="center">
-    Discord-Tauri is a work in progress lightweight wrapper for Discord.
+    Discord Tauri is a work in progress Discord wrapper made in [Tauri](https://tauri.studio).
 </p>
+
+---
+
+# Purpose
+
+I asked myself, how would Discord be if it was built in Tauri? I could only imagine super low memory usage so I got a PoC working in a week.
+
+This project's purpose is to, not only know how Discord would be if it was built in Tauri; but also learn about Discord inner workings and possibly get more people to know about [Tauri](https://tauri.studio)!
+
+# Benchmarks
+
+Made with the same account, same procedure and in the same system.
+Your results may vary.
+If these results are good, they are thanks to Tauri, not because the Discord dev team is bad.
+If these results are bad, well, Tauri is still a good library! Also, good job Discord!
+
+| Detail                         | Discord Tauri | Discord   |
+| ------------------------------ | ------------- | --------- |
+| Installer Size                 | 2.83 MiB      | 67.57 MiB |
+| Installed Size (without Cache) | 20 MiB        | 326 MiB   |
+| Memory Usage                   | 254 MB        | 233 MB    |
+| Launch Time                    | 5.08s         | 7.41s     |
+
+The following results were obtained with an almost brand new account: 3 servers, 1 friend.
+
+| Detail         | Discord Tauri | Discord   |
+| -------------- | ------------- | --------- |
+| Memory Usage   | 175 MB        | 178 MB    |
+| Launch Time    | 3.06s         | 2.83s     |
 
 ---
 
@@ -28,7 +57,7 @@
 
 First, you will need the dependencies needed for Tauri. If you are on Windows, make sure to install the Microsoft Visual Studio C++ Build Tools and WebView2.
 
-You can see the process depending on your operating system <a href="https://tauri.studio/en/docs/getting-started/intro">here</a>!
+You can see the process depending on your operating system <a href="https://tauri.studio/en/docs/getting-started/intro">here</a>! (Linux doesn't work for now!)
 
 ## Prerequisites
 - [Git](https://git-scm.com)
@@ -37,7 +66,7 @@ You can see the process depending on your operating system <a href="https://taur
 
 ### Clone the repository
 ```ps
-git clone https://github.com/elJoa/discord-tauri.git
+git clone https://github.com/DiscordTauri/discord-tauri.git
 ```
 ### Install the project dependencies
 ```ps
@@ -61,8 +90,5 @@ Use `cargo fmt` in `/src-tauri` to use our code style (cough cough, not that we 
 
 # FAQ
 
-### What is discord-tauri?
-It's a Discord wrapper that uses the lightweight library [Tauri](https://tauri.studio). Hopefully, it will allow developers to create plugins or themes. In the current state of development, though, we are still replicating the original Discord client behavior.
-
-### So it will be like BetterDiscord?
-Yes! In fact, this project was highly inspired by BetterDiscord.
+### What is Discord Tauri?
+It's a Discord wrapper that uses the lightweight library [Tauri](https://tauri.studio). In the current state of development, we are replicating the original Discord client behavior.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "discord-tauri"
-version = "0.2.0"
-description = "A Discord wrapper using Tauri"
+version = "0.3.0"
+description = "Discord, built in Tauri."
 authors = [ "DrPuc" ]
-license = ""
-repository = ""
+license = "GPLv3"
+repository = "https://github.com/DiscordTauri/discord-tauri"
 default-run = "discord-tauri"
 edition = "2018"
 build = "src/build.rs"
@@ -15,7 +15,7 @@ tauri-build = { version = "1.0.0-beta.3" }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
-tauri = { version = "1.0.0-beta.5", features = ["api-all", "menu", "system-tray"] }
+tauri = { version = "1.0.0-beta.5", features = ["menu", "notification-all", "system-tray"] }
 reqwest = { version = "0.11.4", features = ["blocking"] }
 
 [features]

--- a/src-tauri/src/plugins/dt_api.rs
+++ b/src-tauri/src/plugins/dt_api.rs
@@ -27,7 +27,7 @@ impl<R: Runtime> Plugin<R> for DtApiPlugin<R> {
   // The JS script to evaluate on initialization
   fn initialization_script(&self) -> Option<String> {
     Some(String::from(
-      "console.log('[DISCORD-TAURI] DtApi loaded.');",
+      "console.log('[DISCORD-TAURI v0.3] DtApi loaded.');",
     ))
   }
 

--- a/src-tauri/src/plugins/notifications.rs
+++ b/src-tauri/src/plugins/notifications.rs
@@ -27,7 +27,7 @@ impl<R: Runtime> Plugin<R> for NotificationsPlugin<R> {
   // The JS script to evaluate on initialization
   fn initialization_script(&self) -> Option<String> {
     Some(String::from(
-      "console.log('[DISCORD-TAURI] Notifications loaded.');",
+      "console.log('[DISCORD-TAURI v0.3] Notifications loaded.');",
     ))
   }
 

--- a/src-tauri/src/plugins/splashscreen.rs
+++ b/src-tauri/src/plugins/splashscreen.rs
@@ -27,7 +27,7 @@ impl<R: Runtime> Plugin<R> for SplashscreenPlugin<R> {
   // The JS script to evaluate on initialization
   fn initialization_script(&self) -> Option<String> {
     Some(String::from(
-      "console.log('[DISCORD-TAURI] Splashscreen loaded.');",
+      "console.log('[DISCORD-TAURI v0.3] Splashscreen loaded.');",
     ))
   }
 

--- a/src-tauri/src/plugins/window_bar.rs
+++ b/src-tauri/src/plugins/window_bar.rs
@@ -30,7 +30,7 @@ impl<R: Runtime> Plugin<R> for WindowBarPlugin<R> {
   // The JS script to evaluate on initialization
   fn initialization_script(&self) -> Option<String> {
     Some(String::from(
-      "console.log('[DISCORD-TAURI] WindowBar loaded.');",
+      "console.log('[DISCORD-TAURI v0.3] WindowBar loaded.');",
     ))
   }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
-    "productName": "discord-tauri",
-    "version": "0.2.0"
+    "productName": "Discord Tauri",
+    "version": "0.3.0"
   },
   "build": {
     "distDir": "../dist",
@@ -28,7 +28,7 @@
       "resources": [],
       "externalBin": [],
       "copyright": "",
-      "category": "DeveloperTool",
+      "category": "Social Networking",
       "shortDescription": "",
       "longDescription": "",
       "deb": {
@@ -53,7 +53,9 @@
       "active": false
     },
     "allowlist": {
-      "all": true
+      "notification": {
+        "all": true
+      }
     },
     "windows": [
       {
@@ -69,7 +71,7 @@
         "center": true
       },
       {
-        "title": "Discord",
+        "title": "Discord Tauri",
         "width": 940,
         "height": 500,
         "resizable": true,


### PR DESCRIPTION
This PR:
- Bumps the version to 0.3.0
- Adds benchmarks to the README
- Adds discord-tauri's purpose to the README
- Adds a warning about Linux to the README
- Modifies the allowlist for Tauri's API so it's more closed
- Changes the window name to Discord Tauri